### PR TITLE
Allow context to be used like a dict.

### DIFF
--- a/tremolo/lib/contexts.py
+++ b/tremolo/lib/contexts.py
@@ -21,3 +21,15 @@ class ServerContext:
 
     def set(self, name, value):
         self.__dict__[name] = value
+
+    def get(self, name, default=None):
+        return self.__dict__.get(name, default)
+
+    def __setitem__(self, name, value):
+        self.__dict__[name] = value
+
+    def __getitem__(self, name):
+        return self.__dict__[name]
+
+    def __delitem__(self, name):
+        del self.__dict__[name]


### PR DESCRIPTION
Allows context to optionally be used like a dict.

Nice because it exposes safe `get()` and `print()` to directly dump the context.

Similar issue in Starlette: https://github.com/encode/starlette/discussions/2389