### PR TITLE
standardize header to bytes

### DIFF
--- a/tremolo/__init__.py
+++ b/tremolo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.603'
+__version__ = '0.0.604'
 
 from .tremolo import Tremolo  # noqa: E402
 from . import exceptions  # noqa: E402,F401

--- a/tremolo/asgi_server.py
+++ b/tremolo/asgi_server.py
@@ -61,8 +61,7 @@ class ASGIServer(HTTPProtocol):
         self._scope = {
             'asgi': {'version': '3.0', 'spec_version': '2.3'},
             'http_version': self.request.version.decode('latin-1'),
-            'path': unquote_to_bytes(
-                bytes(self.request.path)).decode('latin-1'),
+            'path': unquote_to_bytes(self.request.path).decode('latin-1'),
             'raw_path': self.request.path,
             'query_string': self.request.query_string,
             'root_path': self.options['_root_path'],

--- a/tremolo/lib/h1parser/parse_header.py
+++ b/tremolo/lib/h1parser/parse_header.py
@@ -49,19 +49,17 @@ class ParseHeader:
         if header_size < 2:
             return self
 
-        header = data[:header_size]
         self._body = data[header_size + 2:]
-
         start = 0
 
         while True:
-            end = header.find(b'\r\n', start)
+            end = data.find(b'\r\n', start, header_size)
 
             if end == -1:
                 break
 
             max_lines -= 1
-            line = header[start:end]
+            line = bytes(data[start:end])
 
             if max_lines < 0 or end - start > max_line_size or b'\n' in line:
                 self.is_valid_request = False
@@ -108,7 +106,7 @@ class ParseHeader:
 
                 self.headers[b'_line'] = line
             elif colon_pos > 0 and line[colon_pos - 1] != 32:
-                name = bytes(line[:colon_pos].lower())
+                name = line[:colon_pos].lower()
                 value = line[colon_pos + 1:]
 
                 if value.startswith(b' '):


### PR DESCRIPTION
Before:
```python
REMOTE_ADDR:    b'127.0.0.1'
HTTP_HOST:      bytearray(b'localhost:8000')
REQUEST_METHOD: bytearray(b'GET')
REQUEST_SCHEME: b'http'
REQUEST_URI:    bytearray(b'/hello?a=1&b=2')
PATH:           bytearray(b'/hello')
QUERY:          {'a': ['1'], 'b': ['2']}
QUERY_STRING:   bytearray(b'a=1&b=2')
VERSION:        b'1.1'
```
After:
```python
REMOTE_ADDR:    b'127.0.0.1'
HTTP_HOST:      b'localhost:8000'
REQUEST_METHOD: b'GET'
REQUEST_SCHEME: b'http'
REQUEST_URI:    b'/hello?a=1&b=2'
PATH:           b'/hello'
QUERY:          {'a': ['1'], 'b': ['2']}
QUERY_STRING:   b'a=1&b=2'
VERSION:        b'1.1'
```