### PR TITLE
set spawn mode as default

### DIFF
--- a/alltests.py
+++ b/alltests.py
@@ -23,7 +23,7 @@ def main():
                     debug=False,
                     reload=True,
                     loop='asyncio.SelectorEventLoop',
-                    limit_memory=65536,  # 64MiB
+                    limit_memory=102400,  # 100MiB
                     client_max_body_size=73728,  # 72KiB
                     ws_max_payload_size=73728))
     )

--- a/tests/http_server.py
+++ b/tests/http_server.py
@@ -207,7 +207,7 @@ async def trigger_memory_leak(**server):
 
     data = bytearray()
 
-    while initial_memory_usage + len(data) < 64 * 1048576:
+    while initial_memory_usage + len(data) < 100 * 1048576:
         data.extend(b' ' * 1048576)
 
     await asyncio.sleep(10)

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -873,7 +873,7 @@ if __name__ == '__main__':
                     debug=False,
                     reload=True,
                     loop='asyncio.SelectorEventLoop',
-                    limit_memory=65536,  # 64MiB
+                    limit_memory=102400,  # 100MiB
                     client_max_body_size=73728,  # 72KiB
                     ws_max_payload_size=73728)
     )

--- a/tremolo/__init__.py
+++ b/tremolo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.691'
+__version__ = '0.0.700'
 
 from .tremolo import Tremolo  # noqa: E402
 from . import exceptions  # noqa: E402,F401


### PR DESCRIPTION
'fork' mode is complex.

Changed in version 3.12: If Python is able to detect that your process has multiple threads, the [os.fork()](https://docs.python.org/3/library/os.html#os.fork) function that this start method calls internally will raise a [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning). Use a different start method.