### PR TITLE
make the request (and response) parameters leftmost

### DIFF
--- a/tests/http_server.py
+++ b/tests/http_server.py
@@ -289,7 +289,7 @@ async def upload_multipart(stream=False, **server):
 
 
 @app.route('/download')
-async def download(request=None, response=None, **_):
+async def download(request, response, **_):
     if request.query_string == b'executor':
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
             await response.sendfile(
@@ -341,7 +341,7 @@ async def sse_handler(sse=None, **_):
 
 
 @app.route('/timeouts')
-async def timeouts(request=None, **_):
+async def timeouts(request, **_):
     if request.query_string == b'recv':
         # attempt to read body on a GET request
         # should raise a TimeoutError and ended up with a RequestTimeout
@@ -351,7 +351,7 @@ async def timeouts(request=None, **_):
 
 
 @app.route('/reload')
-async def reload(request=None, **_):
+async def reload(request, **_):
     yield b'%d' % hash(app)
 
     if request.query_string != b'':

--- a/tremolo/handlers.py
+++ b/tremolo/handlers.py
@@ -14,7 +14,7 @@ async def error_400(**_):
     raise BadRequest
 
 
-async def error_404(request=None, **_):
+async def error_404(request, **_):
     yield (
         b'<!DOCTYPE html><html lang="en"><head><meta name="viewport" '
         b'content="width=device-width, initial-scale=1.0" />'
@@ -31,7 +31,7 @@ async def error_404(request=None, **_):
     )
 
 
-async def error_500(request=None, exc=None, **_):
+async def error_500(request, exc=None, **_):
     if request.protocol.options['debug']:
         te = TracebackException.from_exception(exc)
         return '<ul><li>%s</li></ul>' % '</li><li>'.join(

--- a/tremolo/http_server.py
+++ b/tremolo/http_server.py
@@ -59,8 +59,8 @@ class HTTPServer(HTTPProtocol):
         self.response.set_base_header()
         self.context.options.update(options)
 
-        data = await func(**self._server,
-                          request=self.request, response=self.response)
+        data = await func(request=self.request, response=self.response,
+                          **self._server)
 
         if data is None:
             return options
@@ -114,8 +114,8 @@ class HTTPServer(HTTPProtocol):
         self.response.set_base_header()
         self.context.options.update(options)
 
-        agen = func(**self._server,
-                    request=self.request, response=self.response)
+        agen = func(request=self.request, response=self.response,
+                    **self._server)
         next_data = getattr(agen, '__anext__', False)
 
         if next_data:

--- a/websocket_chat.py
+++ b/websocket_chat.py
@@ -18,7 +18,7 @@ async def middleware_handler(**server):
 
 
 @app.route('/')
-async def ws_handler(websocket=None, request=None, stream=False, **_):
+async def ws_handler(request, websocket=None, stream=False, **_):
     """A hybrid handler.
 
     Normally, you should separate the http:// and ws:// handlers individually.


### PR DESCRIPTION
Before:
```python
@app.route('/hello')
async def hello_world(request=None, response=None, **server):
    pass
```

After:
```python
@app.route('/hello')
async def hello_world(request, response, **server):
    pass
```

or
```python
@app.route('/hello')
async def hello_world(request, **server):
    pass
```

This means that passing a `None` value is no longer required, as long as the `request` is placed first, and it may be followed by the `response`.