### PR TITLE
fix regression curl "leftovers after chunking" on asgi exc

### DIFF
--- a/examples/upload_and_stream.py
+++ b/examples/upload_and_stream.py
@@ -22,7 +22,7 @@ async def index():
 async def upload(request, response):
     # no worries, if the file is larger than `max_file_size`
     # it can still be read continuously bit by bit according to this size
-    files = request.files(max_file_size=16384)
+    files = request.files(max_file_size=16384)  # 16KiB
 
     # read the initial part to get `Content-Type` information
     part = await anext(files)

--- a/tremolo/asgi_server.py
+++ b/tremolo/asgi_server.py
@@ -292,9 +292,10 @@ class ASGIWrapper:
         except asyncio.CancelledError:
             pass
         except Exception as exc:
-            if self.protocol is None or self.protocol.is_closing():
+            if self.response is None:
                 self.logger.info(
                     'calling send() after the connection is closed'
                 )
             else:
                 self.protocol.print_exception(exc)
+                self.response = None

--- a/tremolo/asgi_server.py
+++ b/tremolo/asgi_server.py
@@ -10,7 +10,7 @@ from .exceptions import (
     WebSocketClientClosed,
     WebSocketServerClosed
 )
-from .handlers import error_400, error_500
+from .handlers import error_400
 from .lib.http_protocol import HTTPProtocol
 from .lib.websocket import WebSocket
 
@@ -88,11 +88,6 @@ class ASGIServer(HTTPProtocol):
             await response.handle_exception(exc)
         finally:
             scope.clear()
-
-    async def error_received(self, exc, response):
-        return await error_500(
-            request=response.request, response=response, exc=exc
-        )
 
 
 class ASGIWrapper:

--- a/tremolo/asgi_server.py
+++ b/tremolo/asgi_server.py
@@ -293,4 +293,4 @@ class ASGIWrapper:
                 )
             else:
                 self.protocol.print_exception(exc)
-                self.response = None
+                self.response = None  # disallows further send()

--- a/tremolo/http_server.py
+++ b/tremolo/http_server.py
@@ -317,9 +317,3 @@ class HTTPServer(HTTPProtocol):
         await self._handle_response(
             self._routes[0][1][1], self._routes[0][1][2]
         )
-
-    async def error_received(self, exc, response):
-        # internal server error
-        return await self._routes[0][-1][1](request=response.request,
-                                            response=response,
-                                            exc=exc)

--- a/tremolo/lib/http_protocol.py
+++ b/tremolo/lib/http_protocol.py
@@ -152,7 +152,10 @@ class HTTPProtocol(asyncio.Protocol):
         raise NotImplementedError
 
     async def error_received(self, exc, response):
-        raise NotImplementedError
+        # internal server error
+        return await self.app.routes[0][-1][1](request=response.request,
+                                               response=response,
+                                               exc=exc)
 
     def handlers_timeout(self):
         if self.request is None or not self.request.upgraded:

--- a/tremolo/lib/http_protocol.py
+++ b/tremolo/lib/http_protocol.py
@@ -349,7 +349,9 @@ class HTTPProtocol(asyncio.Protocol):
                             self.request.http_keepalive = False
 
                             if self in self.globals.connections:
-                                await self._handle_keepalive()
+                                if not self.request.upgraded:
+                                    await self._handle_keepalive()
+
                                 self.transport.resume_reading()
                                 continue
 
@@ -394,9 +396,6 @@ class HTTPProtocol(asyncio.Protocol):
                 break
 
     async def _handle_keepalive(self):
-        if self.request.upgraded:
-            return
-
         if 'receive' in self._waiters:
             # waits for all incoming data to enter the queue
             await self._waiters['receive']

--- a/tremolo/utils.py
+++ b/tremolo/utils.py
@@ -150,6 +150,12 @@ def parse_int(string, base=10):
     if not isinstance(string, (bytes, bytearray)) or not 0 < len(string) <= 16:
         raise ValueError('string must be bytes-like and <=16 in length')
 
+    if string == b'0':
+        return 0
+
+    if string.startswith(b'0'):
+        raise ValueError('string cannot contain leading zeros')
+
     total = 0
 
     for c in string:


### PR DESCRIPTION
by disallowing further `send()` after an exc occurs.