### PR TITLE
don't print_exception on WebSocketClientClosed (asgi)

### DIFF
--- a/tremolo/asgi_server.py
+++ b/tremolo/asgi_server.py
@@ -137,15 +137,15 @@ class ASGIWrapper:
             except (asyncio.CancelledError, Exception) as exc:
                 code = 1005
 
-                if isinstance(exc, WebSocketClientClosed):
-                    code = exc.code
-
                 if self._websocket is None:
                     self.logger.info(
                         'calling receive() after the connection is closed'
                     )
                 else:
-                    self.protocol.print_exception(exc)
+                    if isinstance(exc, WebSocketClientClosed):
+                        code = exc.code
+                    else:
+                        self.protocol.print_exception(exc)
 
                     self.protocol.request = None  # force handler timeout
                     self.protocol.set_handler_timeout(

--- a/tremolo/lib/http_request.py
+++ b/tremolo/lib/http_request.py
@@ -59,7 +59,7 @@ class HTTPRequest(Request):
             if ip == b'' and self.client is not None:
                 self._ip = self.client[0].encode('utf-8')
             else:
-                self._ip = ip[:(ip + b',').find(b',')]
+                self._ip = ip.split(b',', 1)[0]
 
         return self._ip
 


### PR DESCRIPTION
This hides a lot of ws noise that is not so important.