### PR TITLE
recycle the tail data in the buffer

### DIFF
--- a/tremolo/lib/http_protocol.py
+++ b/tremolo/lib/http_protocol.py
@@ -437,6 +437,10 @@ class HTTPProtocol(asyncio.Protocol):
         self.request.clear()
         self.request = None
 
+        if self._receive_buf:
+            self.queue[0].put_nowait(self._receive_buf[:])
+            del self._receive_buf[:]
+
         while self.queue[0].qsize():
             # this data is supposed to be the next header
             self.data_received(self.queue[0].get_nowait())


### PR DESCRIPTION
Force this *tail data* to be processed by the parser (inside `data_received()`). Rather than passively waiting for next `data_received()` to be called by the transport.