### PR TITLE
set request._body to None on upgrade

### DIFF
--- a/tremolo/lib/http_protocol.py
+++ b/tremolo/lib/http_protocol.py
@@ -12,7 +12,6 @@ from .http_exceptions import (
 )
 from .http_header import HTTPHeader
 from .http_request import HTTPRequest
-from .http_response import HTTPResponse
 from .queue import Queue
 
 
@@ -202,7 +201,7 @@ class HTTPProtocol(asyncio.Protocol):
 
     async def _handle_request(self):
         try:
-            response = HTTPResponse(self.request)
+            response = self.request.create_response()
 
             if b'connection' in self.request.headers:
                 if b'close' not in self.request.headers.getlist(b'connection'):

--- a/tremolo/lib/http_request.py
+++ b/tremolo/lib/http_request.py
@@ -7,6 +7,7 @@ from urllib.parse import parse_qs
 
 from tremolo.utils import parse_fields, parse_int
 from .http_exceptions import BadRequest, PayloadTooLarge
+from .http_response import HTTPResponse
 from .request import Request
 
 
@@ -110,6 +111,9 @@ class HTTPRequest(Request):
         )  # 12 Bytes
 
         return prefix + os.urandom(max(4, length - len(prefix)))
+
+    def create_response(self):
+        return HTTPResponse(self)
 
     def clear(self):
         self.header.clear()

--- a/tremolo/lib/http_request.py
+++ b/tremolo/lib/http_request.py
@@ -14,7 +14,7 @@ class HTTPRequest(Request):
     __slots__ = ('_ip', '_scheme', 'header', 'headers', 'is_valid',
                  'host', 'method', 'url', 'path', 'query_string', 'version',
                  'content_length', 'http_continue', 'http_keepalive',
-                 '_upgraded', '_body', '_stream', '_read_buf')
+                 '_body', '_stream', '_read_buf')
 
     def __init__(self, protocol, header):
         super().__init__(protocol)
@@ -40,7 +40,6 @@ class HTTPRequest(Request):
         self.content_length = -1
         self.http_continue = False
         self.http_keepalive = False
-        self._upgraded = False
         self._body = bytearray()
         self._stream = None
         self._read_buf = bytearray()
@@ -85,13 +84,12 @@ class HTTPRequest(Request):
 
     @property
     def upgraded(self):
-        return self._upgraded
+        return self._body is None
 
     @upgraded.setter
     def upgraded(self, value):
-        del self._body[:]
+        self._body = None
         del self._read_buf[:]
-        self._upgraded = value
 
     @property
     def has_body(self):
@@ -117,7 +115,9 @@ class HTTPRequest(Request):
         self.header.clear()
         self.headers.clear()
 
-        del self._body[:]
+        if self._body:
+            del self._body[:]
+
         del self._read_buf[:]
         super().clear()
 

--- a/tremolo/lib/response.py
+++ b/tremolo/lib/response.py
@@ -9,7 +9,7 @@ class Response:
         self._send_buf = bytearray()
 
     def close(self):
-        if self._send_buf != b'':
+        if self._send_buf:
             self.send_nowait(self._send_buf[:])
             del self._send_buf[:]
 


### PR DESCRIPTION
`request.body()` and `request.form()` should not be called after an upgraded connection,

so this should be OK and will add safety as a side effect.