### PR TITLE
rescan if pattern is not found in the routing list

### DIFF
--- a/tests/http_server.py
+++ b/tests/http_server.py
@@ -163,10 +163,12 @@ async def get_query(**server):
     return '&'.join(data)
 
 
-@app.route(r'^/page/(?P<page_id>\d+)')
-async def get_page(**server):
+@app.route(r'^/page/(?P<page_id>\d+)(?:/(?P<request>\w+))?$')
+async def get_page(request, page_id=None, **server):
+    assert request is not None
+
     # b'101'
-    return server['request'].params['path'].get('page_id')
+    return page_id
 
 
 @app.route('/getcookies')

--- a/tremolo/http_server.py
+++ b/tremolo/http_server.py
@@ -273,7 +273,7 @@ class HTTPServer(HTTPProtocol):
                     matches = m.groupdict()
 
                     if matches:
-                        kwargs.update(matches)
+                        kwargs = {**kwargs, **matches}
                     else:
                         matches = m.groups()
 
@@ -294,7 +294,7 @@ class HTTPServer(HTTPProtocol):
                 matches = m.groupdict()
 
                 if matches:
-                    kwargs.update(matches)
+                    kwargs = {**kwargs, **matches}
                 else:
                     matches = m.groups()
 

--- a/tremolo/http_server.py
+++ b/tremolo/http_server.py
@@ -286,7 +286,7 @@ class HTTPServer(HTTPProtocol):
             if m:
                 if key in self.app.routes:
                     self.app.routes[key].append((pattern, func, kwargs))
-                else:
+                elif pattern.pattern.count(b'/') > 1:
                     self.app.routes[key] = [(pattern, func, kwargs)]
 
                 matches = m.groupdict()

--- a/tremolo/http_server.py
+++ b/tremolo/http_server.py
@@ -273,7 +273,8 @@ class HTTPServer(HTTPProtocol):
                     matches = m.groupdict()
 
                     if matches:
-                        kwargs = {**kwargs, **matches}
+                        for k in matches:
+                            self.server.setdefault(k, matches[k])
                     else:
                         matches = m.groups()
 
@@ -294,7 +295,8 @@ class HTTPServer(HTTPProtocol):
                 matches = m.groupdict()
 
                 if matches:
-                    kwargs = {**kwargs, **matches}
+                    for k in matches:
+                        self.server.setdefault(k, matches[k])
                 else:
                     matches = m.groups()
 

--- a/tremolo/http_server.py
+++ b/tremolo/http_server.py
@@ -272,7 +272,9 @@ class HTTPServer(HTTPProtocol):
                 if m:
                     matches = m.groupdict()
 
-                    if not matches:
+                    if matches:
+                        kwargs.update(matches)
+                    else:
                         matches = m.groups()
 
                     request.params['path'] = matches
@@ -291,7 +293,9 @@ class HTTPServer(HTTPProtocol):
 
                 matches = m.groupdict()
 
-                if not matches:
+                if matches:
+                    kwargs.update(matches)
+                else:
                     matches = m.groups()
 
                 request.params['path'] = matches

--- a/tremolo/http_server.py
+++ b/tremolo/http_server.py
@@ -279,30 +279,25 @@ class HTTPServer(HTTPProtocol):
 
                     await self._handle_response(func, kwargs)
                     return
-        else:
-            i = len(self.app.routes[-1])
 
-            while i > 0:
-                i -= 1
-                pattern, func, kwargs = self.app.routes[-1][i]
-                m = pattern.search(request.url)
+        for pattern, func, kwargs in self.app.routes[-1]:
+            m = pattern.search(request.url)
 
-                if m:
-                    if key in self.app.routes:
-                        self.app.routes[key].append((pattern, func, kwargs))
-                    else:
-                        self.app.routes[key] = [(pattern, func, kwargs)]
+            if m:
+                if key in self.app.routes:
+                    self.app.routes[key].append((pattern, func, kwargs))
+                else:
+                    self.app.routes[key] = [(pattern, func, kwargs)]
 
-                    matches = m.groupdict()
+                matches = m.groupdict()
 
-                    if not matches:
-                        matches = m.groups()
+                if not matches:
+                    matches = m.groups()
 
-                    request.params['path'] = matches
+                request.params['path'] = matches
 
-                    await self._handle_response(func, kwargs)
-                    del self.app.routes[-1][i]
-                    return
+                await self._handle_response(func, kwargs)
+                return
 
         # not found
         await self._handle_response(


### PR DESCRIPTION
```python
app.routes = {
    key: [],
    -1: []
}
```

**Facts:** All routes you add with the `@app.route` decorator will be categorized with `key` (bytes).

### Key Formula
```python
path = b'/my/cool/path'
parts = path.strip(b'/').split(b'/', 254)
key = bytes([len(parts)]) + parts[0]  # b'\03my'
```

When the request comes, Tremolo will also obtain keys such as `b'\03my'` from `request.path` which will be used to speed up the lookup.

In dynamic routing with regex, keys **cannot be generated at boot time** (due to its ambiguity), but can be obtained when a request arrives.

So regex routes are initially put in the key group `-1` and when the request comes, they will be (re)populated in such a way as to reduce the iteration to the entire list of `-1`.

In previous Tremolo versions, upon a successful match, the corresponding route would be removed from the `-1` list. This would make the routing very restrictive.

This PR opens up other possibilities to be more flexible.