### PR TITLE
add app.mount

### DIFF
--- a/tests/http_server.py
+++ b/tests/http_server.py
@@ -410,21 +410,23 @@ async def mount(prefix, **server):
 
 
 subsub.routes.add(mount, '/mount')
-sub.routes.add(mount, '/mount')
-
-sub.mount('/subsub', subsub)
-app.mount('/sub', sub)
-
-assert (b'sub', b'subsub') in app.middlewares
+sub.routes.add(mount, 'mount$')
 
 # test multiple ports
 app.listen(HTTP_PORT + 1, request_timeout=1, keepalive_timeout=2,
            app_handler_timeout=2, app_close_timeout=0)
-app.listen(HTTP_PORT + 2)
+sub.listen(HTTP_PORT + 2)
+
+sub.mount('/subsub', subsub)
+app.mount('/sub', sub)
+app.mount('/sub', sub)  # no-op
+
+assert (b'sub', b'subsub') in app.middlewares
 
 # test unix socket
 # 'tremolo-test.sock'
 app.listen('tremolo-test', debug=False, client_max_body_size=1048576)
+
 
 if __name__ == '__main__':
     app.run(HTTP_HOST, port=HTTP_PORT, limit_memory=LIMIT_MEMORY,

--- a/tests/http_server.py
+++ b/tests/http_server.py
@@ -24,6 +24,8 @@ HTTP_PORT = 28000
 TEST_FILE = __file__
 
 app = Application()
+sub = Application()
+subsub = Application()
 
 
 @app.on_worker_start  # priority=999 (low)
@@ -74,14 +76,14 @@ async def worker_stop(**worker):
         assert g.shared > 0
 
 
-@app.on_connect
+@sub.on_connect
 async def on_connect(**server):
     server['context'].foo = 'bar'
 
     return True
 
 
-@app.on_close
+@subsub.on_close
 async def on_close(**server):
     assert server['context'].foo == 'bar'
     server['globals'].options['max_queue_size'] = 128
@@ -395,6 +397,25 @@ async def reload(request, **server):
 
         # simulate a code change
         os.utime(TEST_FILE, (mtime, mtime))
+
+
+@subsub.on_request
+async def subsub_middleware(**server):
+    pass
+
+
+async def mount(prefix, **server):
+    # b'/sub/subsub'
+    return b'/' + b'/'.join(prefix)
+
+
+subsub.routes.add(mount, '/mount')
+sub.routes.add(mount, '/mount')
+
+sub.mount('/subsub', subsub)
+app.mount('/sub', sub)
+
+assert (b'sub', b'subsub') in app.middlewares
 
 # test multiple ports
 app.listen(HTTP_PORT + 1, request_timeout=1, keepalive_timeout=2,

--- a/tests/middlewares.py
+++ b/tests/middlewares.py
@@ -1,11 +1,3 @@
-def on_connect(**_):
-    return b'Halt!'
-
-
-def on_close(**_):
-    return b'Halt!'
-
-
 def on_request(**_):
     return b'Halt!'
 

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -959,6 +959,26 @@ class TestHTTPServer(unittest.TestCase):
 
         self.assertFalse(body2 == body1)
 
+    def test_mount_subsub_with_middleware(self):
+        header, body = getcontents(host=HTTP_HOST,
+                                   port=HTTP_PORT,
+                                   method='GET',
+                                   url='/sub/subsub/mount',
+                                   version='1.1')
+
+        self.assertEqual(header[:header.find(b'\r\n')], b'HTTP/1.1 200 OK')
+        self.assertEqual(read_chunked(body), b'/sub/subsub')
+
+    def test_mount_sub_no_middleware(self):
+        header, body = getcontents(host=HTTP_HOST,
+                                   port=HTTP_PORT,
+                                   method='GET',
+                                   url='/sub/mount/',
+                                   version='1.1')
+
+        self.assertEqual(header[:header.find(b'\r\n')], b'HTTP/1.1 200 OK')
+        self.assertEqual(read_chunked(body), b'/')
+
 
 if __name__ == '__main__':
     mp.set_start_method('spawn', force=True)

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -963,7 +963,7 @@ class TestHTTPServer(unittest.TestCase):
         header, body = getcontents(host=HTTP_HOST,
                                    port=HTTP_PORT,
                                    method='GET',
-                                   url='/sub/subsub/mount',
+                                   url='/sub/subsub/mount/',
                                    version='1.1')
 
         self.assertEqual(header[:header.find(b'\r\n')], b'HTTP/1.1 200 OK')
@@ -973,7 +973,7 @@ class TestHTTPServer(unittest.TestCase):
         header, body = getcontents(host=HTTP_HOST,
                                    port=HTTP_PORT,
                                    method='GET',
-                                   url='/sub/mount/',
+                                   url='/sub/whatevermount',
                                    version='1.1')
 
         self.assertEqual(header[:header.find(b'\r\n')], b'HTTP/1.1 200 OK')

--- a/tests/test_tremolo_objects.py
+++ b/tests/test_tremolo_objects.py
@@ -96,13 +96,13 @@ class TestTremoloObjects(unittest.TestCase):
                 continue
 
             getattr(app, attr_name)(getattr(middlewares, attr_name))
-            _, func, options, _ = app.middlewares[attr_name[3:]][-1]
+            _, func, options = app.middlewares[()][attr_name[3:]][-1]
 
             self.assertEqual(func(), b'Halt!')
             self.assertEqual(options, {})
 
             getattr(app, attr_name)()(getattr(middlewares, attr_name))
-            _, func, options, _ = app.middlewares[attr_name[3:]][-1]
+            _, func, options = app.middlewares[()][attr_name[3:]][-1]
 
             self.assertEqual(func(), b'Halt!')
             self.assertEqual(options, {})

--- a/tests/test_tremolo_objects.py
+++ b/tests/test_tremolo_objects.py
@@ -29,6 +29,12 @@ class TestTremoloObjects(unittest.TestCase):
             # app.run(host=None)
             app.run()
 
+    def test_run_mounted_app(self):
+        app.mount('/', sub)
+
+        with self.assertRaises(RuntimeError):
+            sub.run()
+
     def test_mount_invalid_prefix(self):
         with self.assertRaises(ValueError):
             app.mount('', sub)

--- a/tests/test_tremolo_objects.py
+++ b/tests/test_tremolo_objects.py
@@ -96,13 +96,13 @@ class TestTremoloObjects(unittest.TestCase):
                 continue
 
             getattr(app, attr_name)(getattr(middlewares, attr_name))
-            _, func, options = app.middlewares[attr_name[3:]][-1]
+            _, func, options, _ = app.middlewares[attr_name[3:]][-1]
 
             self.assertEqual(func(), b'Halt!')
             self.assertEqual(options, {})
 
             getattr(app, attr_name)()(getattr(middlewares, attr_name))
-            _, func, options = app.middlewares[attr_name[3:]][-1]
+            _, func, options, _ = app.middlewares[attr_name[3:]][-1]
 
             self.assertEqual(func(), b'Halt!')
             self.assertEqual(options, {})

--- a/tests/test_tremolo_objects.py
+++ b/tests/test_tremolo_objects.py
@@ -17,6 +17,7 @@ from tests.http_server import HTTP_PORT  # noqa: E402
 from tests.utils import syncify  # noqa: E402
 
 app = Application()
+sub = Application()
 
 
 class TestTremoloObjects(unittest.TestCase):
@@ -27,6 +28,22 @@ class TestTremoloObjects(unittest.TestCase):
         with self.assertRaises(ValueError):
             # app.run(host=None)
             app.run()
+
+    def test_mount_invalid_prefix(self):
+        with self.assertRaises(ValueError):
+            app.mount('', sub)
+
+    def test_mount_invalid_prefix_long(self):
+        with self.assertRaises(ValueError):
+            app.mount('/a' * 128, sub)
+
+    def test_mount_invalid_app(self):
+        with self.assertRaises(ValueError):
+            app.mount('/', None)
+
+    def test_mount_invalid_app_self(self):
+        with self.assertRaises(ValueError):
+            app.mount('/', app)
 
     def test_listen(self):
         self.assertTrue(app.listen(8000))

--- a/tremolo/http_server.py
+++ b/tremolo/http_server.py
@@ -8,7 +8,7 @@ from .lib.websocket import WebSocket
 
 class HTTPServer(HTTPProtocol):
     async def _connection_made(self):
-        for _, func, _ in self.app.middlewares['connect']:
+        for _, func, _, _ in self.app.middlewares['connect']:
             if await func(**self.server):
                 break
 
@@ -54,13 +54,14 @@ class HTTPServer(HTTPProtocol):
         while -1 < self.server['next'] < len(self.app.middlewares[name]):
             middleware = self.app.middlewares[name][self.server['next']]
 
-            if await self._handle_middleware(middleware[1], middleware[2]):
-                if reverse:
-                    self.server['next'] = -1
-                else:
-                    self.server['next'] = len(self.app.middlewares[name])
+            if self.request.path.startswith(middleware[3]):
+                if await self._handle_middleware(middleware[1], middleware[2]):
+                    if reverse:
+                        self.server['next'] = -1
+                    else:
+                        self.server['next'] = len(self.app.middlewares[name])
 
-                return True
+                    return True
 
             self.server['next'] += step
 

--- a/tremolo/http_server.py
+++ b/tremolo/http_server.py
@@ -14,12 +14,8 @@ class HTTPServer(HTTPProtocol):
 
     async def _connection_lost(self, exc):
         try:
-            i = len(self.app.hooks['close'])
-
-            while i > 0:
-                i -= 1
-
-                if await self.app.hooks['close'][i][1](**self.server):
+            for _, func in reversed(self.app.hooks['close']):
+                if await func(**self.server):
                     break
         finally:
             super().connection_lost(exc)

--- a/tremolo/tremolo.py
+++ b/tremolo/tremolo.py
@@ -110,7 +110,7 @@ class Tremolo:
 
     def middleware(self, name, *args, priority=999):
         def decorator(func):
-            self.add_middleware(func, name, priority, getoptions(func))
+            self.add_middleware(func, name, priority, kwargs=getoptions(func))
             return func
 
         if len(args) == 1 and callable(args[0]):

--- a/tremolo/tremolo.py
+++ b/tremolo/tremolo.py
@@ -155,9 +155,7 @@ class Tremolo:
         return (host, port) in self.ports
 
     def mount(self, prefix, app):
-        prefix = prefix.rstrip('/').encode('latin-1')
-
-        if prefix.rfind(b'/') != 0:
+        if not prefix.startswith('/'):
             raise ValueError('prefix must start with "/"')
 
         if app is self or not isinstance(app, self.__class__):
@@ -165,6 +163,8 @@ class Tremolo:
 
         if app.routes is self.routes:  # already mounted
             return
+
+        prefix = prefix.rstrip('/').encode('latin-1')
 
         while app.routes:
             _, routes = app.routes.popitem()

--- a/tremolo/tremolo.py
+++ b/tremolo/tremolo.py
@@ -161,9 +161,6 @@ class Tremolo:
         if app is self or not isinstance(app, self.__class__):
             raise ValueError('invalid app')
 
-        if app.routes is self.routes:  # already mounted
-            return
-
         prefix = prefix.rstrip('/').encode('latin-1')
 
         while app.routes:
@@ -192,8 +189,6 @@ class Tremolo:
 
         while app.ports:
             self.ports.setdefault(*app.ports.popitem())
-
-        app.__dict__.update(self.__dict__)
 
     async def _serve(self, host, port, **kwargs):
         options = self.context.options
@@ -577,7 +572,7 @@ class Tremolo:
                 # we need to update/rebind objects like
                 # routes, middlewares, etc.
                 for attr in module.__dict__.values():
-                    if isinstance(attr, self.__class__):
+                    if isinstance(attr, self.__class__) and attr.routes:
                         self.__dict__.update(attr.__dict__)
         elif process.exitcode != 0:
             print(
@@ -644,9 +639,7 @@ class Tremolo:
                 print('Routes:')
 
                 for routes in self.routes.values():
-                    for route in routes:
-                        pattern, func, kw = route
-
+                    for pattern, func, kw in routes:
                         print(
                             '  %s -> %s(%s)' %
                             (pattern,

--- a/tremolo/tremolo.py
+++ b/tremolo/tremolo.py
@@ -181,9 +181,9 @@ class Tremolo:
         while app.middlewares:
             name, middlewares = app.middlewares.popitem()
 
-            for priority, func, kwargs, _ in middlewares:
+            for priority, func, kwargs, p in middlewares:
                 self.add_middleware(func, name, priority, kwargs=kwargs,
-                                    prefix=prefix + b'/')
+                                    prefix=prefix + p)
 
         while app.hooks:
             name, hooks = app.hooks.popitem()

--- a/tremolo/tremolo.py
+++ b/tremolo/tremolo.py
@@ -628,6 +628,9 @@ class Tremolo:
 
                 kwargs['app'] = '%s:%s' % (__main__.__file__, attr_name)
         else:
+            if not self.routes:
+                raise RuntimeError('cannot run this app. mounted somewhere?')
+
             kwargs['app'] = None
 
             if hasattr(__main__, '__file__'):

--- a/tremolo/tremolo.py
+++ b/tremolo/tremolo.py
@@ -178,14 +178,15 @@ class Tremolo:
         while app.middlewares:
             name, middlewares = app.middlewares.popitem()
 
-            if name in self.middlewares:
-                self.middlewares[name].extend(middlewares)
+            for priority, func, kwargs in middlewares:
+                self.add_middleware(func, name=name, priority=priority,
+                                    kwargs=kwargs)
 
         while app.hooks:
             name, hooks = app.hooks.popitem()
 
-            if name in self.hooks:
-                self.hooks[name].extend(hooks)
+            for priority, func in hooks:
+                self.add_hook(func, name=name, priority=priority)
 
         while app.ports:
             self.ports.setdefault(*app.ports.popitem())


### PR DESCRIPTION
Bottle's `app.mount` can be implemented without much refactoring. Behavior may differ slightly due to underlying design choices.

- [x] Nested mounts are supported.

```python
from tremolo import Application

main = Application()
sub = Application()
subsub = Application()

# main.run() -> http://localhost:8000/sub/subsub/hello
@subsub.route('/hello')
async def hello_world(**server):
    return 'Hello world!', 'latin-1'


sub.mount('/subsub', subsub)
main.mount('/sub', sub)


if __name__ == '__main__':
    main.run('0.0.0.0', 8000, debug=True)
```
- [x] The middlewares (`@app.on_request`) applied to the *sub* application are independent/isolated
- [x] The middlewares (`@app.on_request`) applied to the *main* application are global (only when the sub has no middleware)
- [x] Hooks (`@app.on_worker_start`) that are applied *anywhere* are global, affecting all parties. Order can be by setting `priority=999`, etc.
- [x] Multiple `mount` invocations on the same app are idempotent.
```python
app.mount('/sub', otherapp)
app.mount('/sub', otherapp)
```
- [x] Handle large sub-apps without degrading the middleware lookup
- [ ] Tested