### PR TITLE
support synchronous handlers using threads

### DIFF
--- a/tests/http_server.py
+++ b/tests/http_server.py
@@ -142,25 +142,19 @@ async def get_ip(**server):
 
 
 @app.route('/gethost')
-async def get_host(**server):
+def get_host(**server):
     # b'localhost:28000'
     return server['request'].host
 
 
 @app.route('/getquery')
-async def get_query(**server):
-    request = server['request']
-
+def get_query(request, **server):
     assert request.query['a'] == ['111', 'xyz']
     assert request.query['b'] == ['222']
 
-    data = []
-
+    # b'a=111&b=222&'
     for name, value in request.query.items():
-        data.append('%s=%s' % (name, value[0]))
-
-    # b'a=111&b=222'
-    return '&'.join(data)
+        yield f'{name}={value[0]}&'.encode()
 
 
 @app.route(r'^/page/(?P<page_id>\d+)(?:/(?P<request>\w+))?$')

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -133,7 +133,7 @@ class TestHTTPServer(unittest.TestCase):
                                    version='1.1')
 
         self.assertEqual(header[:header.find(b'\r\n')], b'HTTP/1.1 200 OK')
-        self.assertEqual(read_chunked(body), b'a=111&b=222')
+        self.assertEqual(read_chunked(body), b'a=111&b=222&')
 
     def test_get_page_11(self):
         header, body = getcontents(host=HTTP_HOST,

--- a/tremolo/__main__.py
+++ b/tremolo/__main__.py
@@ -26,6 +26,8 @@ def usage(**context):
     print('                            Multiple binds can be separated by commas')  # noqa: E501
     print('                            E.g. "127.0.0.1:8000,:8001"')
     print('  --worker-num              Number of worker processes. Defaults to 1')  # noqa: E501
+    print('  --thread-pool-size        Number of executor threads per process')  # noqa: E501
+    print('                            Defaults to 5')
     print('  --limit-memory            Restart the worker if this limit (in KiB) is reached')  # noqa: E501
     print('                            (Linux-only). Defaults to 0 or unlimited')  # noqa: E501
     print('  --backlog                 Maximum number of pending connections')

--- a/tremolo/http_server.py
+++ b/tremolo/http_server.py
@@ -121,7 +121,7 @@ class HTTPServer(HTTPProtocol):
             response.set_content_type(options['content_type'])
 
         try:
-            agen = func(**self.server)
+            agen = func(func=func, kwargs=kwargs, **self.server)
         except TypeError:  # doesn't accept extra **kwargs
             agen = func(**{k: self.server.get(k, kwargs[k]) for k in kwargs})
 

--- a/tremolo/lib/contexts.py
+++ b/tremolo/lib/contexts.py
@@ -47,6 +47,10 @@ class WorkerContext(Context):
     def connections(self):
         return self.__dict__.get('connections', None)
 
+    @property
+    def executor(self):
+        return self.__dict__.get('executor', None)
+
 
 class ConnectionContext(Context):
     __slots__ = ('_tasks',)  # won't appear in self.__dict__. safe from clear()

--- a/tremolo/lib/executors.py
+++ b/tremolo/lib/executors.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2023 nggit
+
+import asyncio
+import queue
+
+from functools import wraps
+from inspect import isgeneratorfunction
+from threading import Thread
+
+
+def set_result(fut, result):
+    if not fut.done():
+        fut.set_result(result)
+
+
+def set_exception(fut, exc):
+    if not fut.done():
+        fut.set_exception(exc)
+
+
+class ThreadExecutor(Thread):
+    def __init__(self, context, loop=None, **kwargs):
+        super().__init__(**kwargs)
+
+        self.context = context
+        self.queue = queue.SimpleQueue()
+        self.loop = loop or asyncio.get_event_loop()
+        self._shutdown = None
+
+    def run(self):
+        while True:
+            try:
+                self.context.thread = self  # update the last active thread
+                fut, func, args, kwargs = self.queue.get(timeout=1)
+            except queue.Empty:
+                continue
+
+            if func is None:
+                self.loop.call_soon_threadsafe(self.join)
+                self.loop.call_soon_threadsafe(set_result, fut, None)
+                break
+
+            try:
+                self.loop.call_soon_threadsafe(
+                    set_result, fut, func(*args, **kwargs)
+                )
+            except StopIteration:
+                # StopIteration interacts badly with generators
+                # and cannot be raised into a Future
+                self.loop.call_soon_threadsafe(fut.cancel)
+            except BaseException as exc:
+                self.loop.call_soon_threadsafe(set_exception, fut, exc)
+
+    def submit(self, func, *args, **kwargs):
+        if not self.is_alive():
+            raise RuntimeError(
+                'calling submit() before start() or after shutdown()'
+            )
+
+        if isgeneratorfunction(func):
+            gen = func(*args, **kwargs)
+
+            @wraps(func)
+            async def wrapper():
+                while True:
+                    fut = self.loop.create_future()
+                    self.queue.put_nowait((fut, gen.__next__, (), {}))
+
+                    try:
+                        yield await fut
+                    except asyncio.CancelledError:
+                        break
+
+            return wrapper()
+
+        if callable(func):
+            fut = self.loop.create_future()
+            self.queue.put_nowait((fut, func, args, kwargs))
+
+            return fut
+
+        raise TypeError(f'{str(func)} is not generator function or callable')
+
+    def shutdown(self):
+        if self._shutdown is None:
+            self._shutdown = self.loop.create_future()
+
+            if self.is_alive():
+                self.queue.put_nowait((self._shutdown, None, None, None))
+
+        if not self.is_alive():
+            set_result(self._shutdown, None)
+
+        return self._shutdown
+
+
+class MultiThreadExecutor:
+    def __init__(self, size=5):
+        self.size = size
+        self.threads = []
+        self.thread = None  # points to the last active thread
+
+    def start(self, prefix='MultiThreadExecutor', **kwargs):
+        while len(self.threads) < self.size:
+            self.thread = ThreadExecutor(
+                self, name=f'{prefix}-{len(self.threads)}', **kwargs
+            )
+            self.thread.start()
+            self.threads.append(self.thread)
+
+    def submit(self, func, args=(), kwargs={}, name=None):
+        if self.size == 0 or len(self.threads) != self.size:
+            raise RuntimeError('no running threads')
+
+        if name is None:
+            return self.thread.submit(func, *args, **kwargs)
+
+        return self.threads[name % self.size].submit(func, *args, **kwargs)
+
+    async def shutdown(self):
+        self.size = 0
+
+        while self.threads:
+            await self.threads.pop().shutdown()

--- a/tremolo/lib/http_response.py
+++ b/tremolo/lib/http_response.py
@@ -275,11 +275,12 @@ class HTTPResponse(Response):
 
         kwargs.setdefault('rate', self.request.server.options['download_rate'])
         kwargs['buffer_size'] = buffer_size
+        g = self.request.server.globals
         loop = self.request.server.loop
 
         def run_sync(func, *args):
             if executor is None:
-                return loop.run_in_executor(None, func, *args)
+                return g.executor.submit(func, args=args)
 
             fut = executor.submit(func, *args)
 

--- a/tremolo/routes.py
+++ b/tremolo/routes.py
@@ -62,7 +62,6 @@ class Routes(dict):
                 else:
                     @wraps(func)
                     def wrapper(func, kwargs, **server):
-                        kw = {k: server.get(k, kwargs[k]) for k in kwargs}
-                        return executor.submit(func.__wrapped__, kwargs=kw)
+                        return executor.submit(func.__wrapped__, kwargs=server)
 
                 self[key][i] = (pattern, wrapper, kwargs)

--- a/tremolo/tremolo.py
+++ b/tremolo/tremolo.py
@@ -209,7 +209,7 @@ class Tremolo:
         if options['app'] is None:
             from .http_server import HTTPServer as Server
 
-            self.routes.compile()
+            self.routes.compile(executor=executor)
         else:
             from .asgi_lifespan import ASGILifespan
             from .asgi_server import ASGIServer as Server

--- a/tremolo/tremolo.py
+++ b/tremolo/tremolo.py
@@ -11,7 +11,6 @@ import socket  # noqa: E402
 import ssl  # noqa: E402
 import sys  # noqa: E402
 
-from functools import wraps  # noqa: E402
 from importlib import import_module, reload as reload_module  # noqa: E402
 from shutil import get_terminal_size  # noqa: E402
 
@@ -66,40 +65,28 @@ class Tremolo:
             return self.error(path)
 
         def decorator(func):
-            @wraps(func)
-            def wrapper(**kwargs):
-                return func(**kwargs)
-
-            self.routes.add(wrapper, path, getoptions(func))
-            return wrapper
+            self.routes.add(func, path, getoptions(func))
+            return func
 
         return decorator
 
     def error(self, code):
         def decorator(func):
-            @wraps(func)
-            def wrapper(**kwargs):
-                return func(**kwargs)
-
             for i, h in enumerate(self.routes[0]):
                 if code == h[0]:
                     self.routes[0][i] = (
-                        h[0], wrapper, dict(h[2], **getoptions(func))
+                        h[0], func, dict(h[2], **getoptions(func))
                     )
                     break
 
-            return wrapper
+            return func
 
         return decorator
 
     def hook(self, name, *args, priority=999):
         def decorator(func):
-            @wraps(func)
-            def wrapper(**kwargs):
-                return func(**kwargs)
-
-            self.add_hook(wrapper, name, priority)
-            return wrapper
+            self.add_hook(func, name, priority)
+            return func
 
         if len(args) == 1 and callable(args[0]):
             return decorator(args[0])
@@ -114,12 +101,8 @@ class Tremolo:
 
     def middleware(self, name, *args, priority=999):
         def decorator(func):
-            @wraps(func)
-            def wrapper(**kwargs):
-                return func(**kwargs)
-
-            self.add_middleware(wrapper, name, priority, getoptions(func))
-            return wrapper
+            self.add_middleware(func, name, priority, getoptions(func))
+            return func
 
         if len(args) == 1 and callable(args[0]):
             return decorator(args[0])

--- a/tremolo/utils.py
+++ b/tremolo/utils.py
@@ -82,6 +82,7 @@ def parse_args(**callbacks):
             options[name] = sys.argv[i]
         elif sys.argv[i - 1] in ('--port',
                                  '--worker-num',
+                                 '--thread-pool-size',
                                  '--limit-memory',
                                  '--backlog',
                                  '--download-rate',

--- a/tremolo/utils.py
+++ b/tremolo/utils.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2023 nggit
 
-__all__ = ('file_signature', 'getoptions', 'html_escape', 'log_date',
-           'memory_usage', 'parse_args', 'parse_fields', 'parse_int',
-           'print_logo', 'server_date')
+__all__ = ('file_signature', 'getoptions', 'html_escape', 'is_async',
+           'log_date', 'memory_usage', 'parse_args', 'parse_fields',
+           'parse_int', 'print_logo', 'server_date')
 
 import os  # noqa: E402
 import stat  # noqa: E402
@@ -10,6 +10,7 @@ import sys  # noqa: E402
 
 from datetime import datetime, timezone  # noqa: E402
 from html import escape  # noqa: E402
+from inspect import iscoroutinefunction, isasyncgenfunction  # noqa: E402
 from urllib.parse import unquote_to_bytes as unquote  # noqa: E402
 
 
@@ -44,6 +45,10 @@ def html_escape(data):
             .replace(b'<', b'&lt;')
             .replace(b'>', b'&gt;')
             .replace(b'"', b'&quot;'))
+
+
+def is_async(func):
+    return iscoroutinefunction(func) or isasyncgenfunction(func)
 
 
 def log_date():


### PR DESCRIPTION
```python
from threading import current_thread


@app.route('/')
def sync_handler(request, **server):
    return current_thread().name
```

Unlike the standard library's `ThreadPoolExecutor`, we aim to create a custom executor **that allows us to choose which thread to run on (deterministically)**. E.g. `executor.submit(func, name=THREAD_NUM)`. To support thread-sensitive objects later on.

The executor is created by reusing the [awaiter](https://github.com/nggit/awaiter) code, simplified to be more specific to Tremolo.

**Good:**
Determining `is_async` or not is *ahead of time* (compiled when the worker starts. See `Routes.compile`). It certainly saves checking thousands of times, especially when your application has many requests coming in. So supporting both `async` and sync handlers at the same time incurs **no** overhead.

**Limitations:**
- `**server` / `**kwargs` is required for sync handlers to work