### PR TITLE
add AsyncToSyncWrapper

### DIFF
--- a/tests/http_server.py
+++ b/tests/http_server.py
@@ -244,10 +244,10 @@ async def trigger_memory_leak(**server):
 
 
 @app.route('/submitform')
-async def post_form(**server):
+def post_form(**server):
     request = server['request']
 
-    await request.form(max_size=8192)
+    request.form(max_size=8192)
 
     data = []
 
@@ -259,18 +259,18 @@ async def post_form(**server):
 
 
 @app.route('/upload')
-async def upload(request, content_type=b'application/octet-stream'):
+def upload(request, content_type=b'application/octet-stream', **server):
     if request.query_string == b'maxqueue':
         request.protocol.options['max_queue_size'] = 0
 
     try:
         size = int(request.query['size'][0])
-        yield (await request.read(0)) + (await request.read(size))
+        yield request.read(0) + request.read(size)
     except KeyError:
-        async for data in request.stream():
+        for data in request.stream():
             yield data
 
-        async for data in request.stream():
+        for data in request.stream():
             # should not raised
             raise Exception('EOF!!!')
 

--- a/tremolo/lib/http_request.py
+++ b/tremolo/lib/http_request.py
@@ -132,8 +132,8 @@ class HTTPRequest(Request):
 
         return self._body
 
-    def read(self, size=-1, *, timeout=None):
-        return self.recv(size, timeout=timeout, raw=False)
+    async def read(self, size=-1, *, timeout=None):
+        return await self.recv(size, timeout=timeout, raw=False)
 
     def eof(self):
         return self.content_length == 0 and self._read_buf == b''

--- a/tremolo/lib/http_response.py
+++ b/tremolo/lib/http_response.py
@@ -275,12 +275,11 @@ class HTTPResponse(Response):
 
         kwargs.setdefault('rate', self.request.server.options['download_rate'])
         kwargs['buffer_size'] = buffer_size
-        g = self.request.server.globals
         loop = self.request.server.loop
 
         def run_sync(func, *args):
             if executor is None:
-                return g.executor.submit(func, args=args)
+                return loop.run_in_executor(None, func, *args)
 
             fut = executor.submit(func, *args)
 

--- a/tremolo/routes.py
+++ b/tremolo/routes.py
@@ -5,7 +5,7 @@ import re
 from functools import wraps
 
 from . import handlers
-from .utils import getoptions, is_async
+from .utils import getoptions, is_async, to_sync
 
 
 class Routes(dict):
@@ -61,7 +61,10 @@ class Routes(dict):
                     wrapper = func
                 else:
                     @wraps(func)
-                    def wrapper(func, kwargs, **server):
+                    def wrapper(func, kwargs, request, response, **server):
+                        server['request'] = to_sync(request, server['loop'])
+                        server['response'] = to_sync(response, server['loop'])
+
                         return executor.submit(func.__wrapped__, kwargs=server)
 
                 self[key][i] = (pattern, wrapper, kwargs)

--- a/tremolo/utils.py
+++ b/tremolo/utils.py
@@ -215,7 +215,7 @@ class AsyncToSyncWrapper:
                         fut = run_coroutine(agen.__anext__(), self.loop)
                         yield fut.result()
                     except StopAsyncIteration:
-                        return
+                        break
 
             return generator
 


### PR DESCRIPTION
Synchronous handlers is already supported in https://github.com/nggit/tremolo/pull/286 .

But the problem is a bit awkward accessing coroutine objects like `request.form()` or `request.body()`.
As we cannot use `await` inside regular functions!

A minimal solution is to implement `AsyncToSyncWrapper` or `to_sync`. This allows calls without `await`.

```python
@app.route('/async')
async def async_handler(request, **server):
    print(request)  # <tremolo.lib.http_request.HTTPRequest object at 0x...>

    data = await request.body()
    return data


@app.route('/sync')
def sync_handler(request, **server):
    print(request)  # <tremolo.utils.AsyncToSyncWrapper object at 0x...>

    data = request.body()  # it works!
    return data

```
