### PR TITLE
ensure thread safety

### DIFF
--- a/tremolo/lib/executors.py
+++ b/tremolo/lib/executors.py
@@ -30,7 +30,9 @@ class ThreadExecutor(Thread):
     def run(self):
         while self.loop.is_running():
             try:
-                self.context.thread = self  # update the last active thread
+                self.loop.call_soon_threadsafe(  # set the last active thread
+                    self.context.__setattr__, 'thread', self
+                )
                 fut, func, args, kwargs = self.queue.get(timeout=1)
             except queue.Empty:
                 continue


### PR DESCRIPTION
> Built-in types like [dict](https://docs.python.org/3/library/stdtypes.html#dict), [list](https://docs.python.org/3/library/stdtypes.html#list), and [set](https://docs.python.org/3/library/stdtypes.html#set) use internal locks to protect against concurrent modifications in ways that behave similarly to the GIL. However, Python has not historically guaranteed specific behavior for concurrent modifications to these built-in types, so this should be treated as a description of the current implementation, not a guarantee of current or future behavior.

https://docs.python.org/3/howto/free-threading-python.html#thread-safety