### PR TITLE
support decorating classes / class-based views

### DIFF
--- a/tests/http_server.py
+++ b/tests/http_server.py
@@ -399,6 +399,15 @@ async def reload(request, **server):
         os.utime(TEST_FILE, (mtime, mtime))
 
 
+@app.route('/resource')
+class HelloWorld:
+    async def get(self, **server):
+        return 'Hello, World!'
+
+    # async def post(self, request, **server):
+    #    return await request.body()
+
+
 @subsub.on_request
 async def subsub_middleware(**server):
     pass

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -980,6 +980,26 @@ class TestHTTPServer(unittest.TestCase):
         self.assertEqual(header[:header.find(b'\r\n')], b'HTTP/1.1 200 OK')
         self.assertEqual(read_chunked(body), b'/')
 
+    def test_class_get(self):
+        header, body = getcontents(host=HTTP_HOST,
+                                   port=HTTP_PORT,
+                                   method='GET',
+                                   url='/resource',
+                                   version='1.1')
+
+        self.assertEqual(header[:header.find(b'\r\n')], b'HTTP/1.1 200 OK')
+        self.assertEqual(read_chunked(body), b'Hello, World!')
+
+    def test_class_post_notfound(self):
+        header, body = getcontents(host=HTTP_HOST,
+                                   port=HTTP_PORT,
+                                   method='POST',
+                                   url='/resource',
+                                   version='1.1')
+
+        self.assertEqual(header[:header.find(b'\r\n')],
+                         b'HTTP/1.1 404 Not Found')
+
 
 if __name__ == '__main__':
     mp.set_start_method('spawn', force=True)

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -990,7 +990,7 @@ class TestHTTPServer(unittest.TestCase):
         self.assertEqual(header[:header.find(b'\r\n')], b'HTTP/1.1 200 OK')
         self.assertEqual(read_chunked(body), b'Hello, World!')
 
-    def test_class_post_notfound(self):
+    def test_class_post_methodnotallowed(self):
         header, body = getcontents(host=HTTP_HOST,
                                    port=HTTP_PORT,
                                    method='POST',
@@ -998,7 +998,7 @@ class TestHTTPServer(unittest.TestCase):
                                    version='1.1')
 
         self.assertEqual(header[:header.find(b'\r\n')],
-                         b'HTTP/1.1 404 Not Found')
+                         b'HTTP/1.1 405 Method Not Allowed')
 
 
 if __name__ == '__main__':

--- a/tests/test_tremolo_objects.py
+++ b/tests/test_tremolo_objects.py
@@ -59,21 +59,21 @@ class TestTremoloObjects(unittest.TestCase):
 
     def test_route(self):
         app.route('/hello')(handlers.hello)
-        pattern, func, options = app.routes[b'\x01hello'][-1]
+        pattern, func, options, _ = app.routes[b'\x01hello'][-1]
 
         self.assertEqual(pattern, b'^/+hello(?:/+)?(?:\\?.*)?$')
         self.assertEqual(func(), b'Hello!')
         self.assertEqual(options, {})
 
         app.route('/hello/world')(handlers.hello_world)
-        pattern, func, options = app.routes[b'\x02hello'][-1]
+        pattern, func, options, _ = app.routes[b'\x02hello'][-1]
 
         self.assertEqual(pattern, b'^/+hello/world(?:/+)?(?:\\?.*)?$')
         self.assertEqual(func(), b'Hello, World!')
         self.assertEqual(options, {'a': 1, 'b': 2})
 
         app.route('/hello/python')(handlers.hello_python)
-        pattern, func, options = app.routes[b'\x02hello'][-1]
+        pattern, func, options, _ = app.routes[b'\x02hello'][-1]
 
         self.assertEqual(pattern, b'^/+hello/python(?:/+)?(?:\\?.*)?$')
         self.assertEqual(func(), b'Hello, Python!')
@@ -81,7 +81,7 @@ class TestTremoloObjects(unittest.TestCase):
 
     def test_route_index(self):
         app.route('/')(handlers.index)
-        pattern, func, options = app.routes[1][-1]
+        pattern, func, options, _ = app.routes[1][-1]
 
         self.assertEqual(pattern, b'^/+(?:\\?.*)?$')
         self.assertEqual(func(), b'Index!')
@@ -89,14 +89,14 @@ class TestTremoloObjects(unittest.TestCase):
 
     def test_route_regex(self):
         app.route(r'^/page/(?P<page_id>\d+)')(handlers.my_page)
-        pattern, func, options = app.routes[-1][-1]
+        pattern, func, options, _ = app.routes[-1][-1]
 
         self.assertEqual(pattern, b'^/page/(?P<page_id>\\d+)')
         self.assertEqual(func(), b'My Page!')
         self.assertEqual(options, {})
 
         app.routes.compile()
-        pattern, func, options = app.routes[-1][-1]
+        pattern, func, options, _ = app.routes[-1][-1]
 
         self.assertEqual(pattern.pattern, b'^/page/(?P<page_id>\\d+)')
         self.assertEqual(func(), b'My Page!')
@@ -105,7 +105,7 @@ class TestTremoloObjects(unittest.TestCase):
     def test_route_error(self):
         app.route(404)(handlers.error_404)
 
-        for code, func, options in app.routes[0]:
+        for code, func, options, _ in app.routes[0]:
             if code == 404:
                 self.assertEqual(func(), b'Not Found!!!')
                 self.assertEqual(options['status'], (404, b'Not Found'))

--- a/tremolo/handlers.py
+++ b/tremolo/handlers.py
@@ -2,7 +2,7 @@
 
 from traceback import TracebackException
 
-from .exceptions import BadRequest
+from .exceptions import BadRequest, MethodNotAllowed
 from .utils import html_escape
 
 
@@ -29,6 +29,10 @@ async def error_404(request, globals, **_):
         b'<address title="Powered by Tremolo">%s</address>'
         b'</body></html>' % globals.info['server_name']
     )
+
+
+async def error_405(**_):
+    raise MethodNotAllowed
 
 
 async def error_500(request, exc=None, **_):

--- a/tremolo/http_server.py
+++ b/tremolo/http_server.py
@@ -285,6 +285,12 @@ class HTTPServer(HTTPProtocol):
                     matches = m.groupdict()
                     request.params['path'] = matches or m.groups()
 
+                    if 'self' in kwargs:
+                        if request.method != func.__name__.upper().encode():
+                            continue
+
+                        matches['self'] = kwargs['self']()
+
                     for k in list(matches):
                         if k in self.server:
                             del matches[k]
@@ -314,6 +320,12 @@ class HTTPServer(HTTPProtocol):
 
                 matches = m.groupdict()
                 request.params['path'] = matches or m.groups()
+
+                if 'self' in kwargs:
+                    if request.method != func.__name__.upper().encode():
+                        continue
+
+                    matches['self'] = kwargs['self']()
 
                 for k in list(matches):
                     if k in self.server:

--- a/tremolo/http_server.py
+++ b/tremolo/http_server.py
@@ -277,6 +277,8 @@ class HTTPServer(HTTPProtocol):
         if key not in self.app.routes:
             key = parts[0]
 
+        error = 1
+
         if key in self.app.routes:
             for pattern, func, kwargs in self.app.routes[key]:
                 m = pattern.search(request.url)
@@ -287,6 +289,7 @@ class HTTPServer(HTTPProtocol):
 
                     if 'self' in kwargs:
                         if request.method != func.__name__.upper().encode():
+                            error = 2
                             continue
 
                         matches['self'] = kwargs['self']()
@@ -323,6 +326,7 @@ class HTTPServer(HTTPProtocol):
 
                 if 'self' in kwargs:
                     if request.method != func.__name__.upper().encode():
+                        error = 2
                         continue
 
                     matches['self'] = kwargs['self']()
@@ -340,7 +344,7 @@ class HTTPServer(HTTPProtocol):
                     for k in matches:
                         del self.server[k]
 
-        # not found
+        # error = 1 (not found), error = 2 (method not allowed)
         await self._handle_response(
-            self.app.routes[0][1][1], self.app.routes[0][1][2]
+            self.app.routes[0][error][1], self.app.routes[0][error][2]
         )

--- a/tremolo/http_server.py
+++ b/tremolo/http_server.py
@@ -280,7 +280,7 @@ class HTTPServer(HTTPProtocol):
         error = 1
 
         if key in self.app.routes:
-            for p, func, kwargs in self.app.routes[key]:
+            for p, func, kwargs, options in self.app.routes[key]:
                 m = p.search(request.url)
 
                 if m:
@@ -292,7 +292,7 @@ class HTTPServer(HTTPProtocol):
                             error = 2
                             continue
 
-                        matches['self'] = kwargs['self']()
+                        matches['self'] = kwargs['self'](**options)
 
                     for k in list(matches):
                         if k in self.server:
@@ -312,7 +312,7 @@ class HTTPServer(HTTPProtocol):
 
             while i > 0:
                 i -= 1
-                p, func, kwargs = self.app.routes[-1][i]
+                p, func, kwargs, options = self.app.routes[-1][i]
                 m = p.search(request.url)
 
                 if m:
@@ -332,7 +332,7 @@ class HTTPServer(HTTPProtocol):
                             error = 2
                             continue
 
-                        matches['self'] = kwargs['self']()
+                        matches['self'] = kwargs['self'](**options)
 
                     for k in list(matches):
                         if k in self.server:

--- a/tremolo/routes.py
+++ b/tremolo/routes.py
@@ -66,6 +66,10 @@ class Routes(dict):
                     def wrapper(func, kwargs, request, response, **server):
                         server['request'] = to_sync(request, server['loop'])
                         server['response'] = to_sync(response, server['loop'])
+                        obj = server.pop('self', None)
+
+                        if obj:
+                            func.__wrapped__ = getattr(obj, func.__name__)
 
                         return executor.submit(func.__wrapped__, kwargs=server)
 

--- a/tremolo/routes.py
+++ b/tremolo/routes.py
@@ -16,6 +16,8 @@ class Routes(dict):
                                            globals=None,
                                            status=(404, b'Not Found'),
                                            stream=False)),
+            (405, handlers.error_405, {}),
+
             # must be at the very end
             (500, handlers.error_500, {})
         ]

--- a/tremolo/routes.py
+++ b/tremolo/routes.py
@@ -11,25 +11,25 @@ from .utils import getoptions, is_async, to_sync
 class Routes(dict):
     def __init__(self):
         self[0] = [
-            (400, handlers.error_400, {}),
+            (400, handlers.error_400, {}, {}),
             (404, handlers.error_404, dict(request=None,
                                            globals=None,
                                            status=(404, b'Not Found'),
-                                           stream=False)),
-            (405, handlers.error_405, {}),
+                                           stream=False), {}),
+            (405, handlers.error_405, {}, {}),
 
             # must be at the very end
-            (500, handlers.error_500, {})
+            (500, handlers.error_500, {}, {})
         ]
         self[1] = [
             (
                 b'^/+(?:\\?.*)?$',
-                handlers.index, dict(status=(503, b'Service Unavailable'))
+                handlers.index, dict(status=(503, b'Service Unavailable')), {}
             )
         ]
         self[-1] = []
 
-    def add(self, func, path='/', kwargs=None):
+    def add(self, func, path='/', kwargs=None, **options):
         if not kwargs:
             kwargs = getoptions(func)
 
@@ -51,13 +51,13 @@ class Routes(dict):
                 pattern = b'^/+%s(?:/+)?(?:\\?.*)?$' % path
 
         if key != 1 and key in self:
-            self[key].append((pattern, func, kwargs))
+            self[key].append((pattern, func, kwargs, options))
         else:
-            self[key] = [(pattern, func, kwargs)]
+            self[key] = [(pattern, func, kwargs, options)]
 
     def compile(self, executor=None):
         for key in self:
-            for i, (pattern, func, kwargs) in enumerate(self[key]):
+            for i, (pattern, func, kwargs, options) in enumerate(self[key]):
                 if isinstance(pattern, bytes):
                     pattern = re.compile(pattern)
 
@@ -75,4 +75,4 @@ class Routes(dict):
 
                         return executor.submit(func.__wrapped__, kwargs=server)
 
-                self[key][i] = (pattern, wrapper, kwargs)
+                self[key][i] = (pattern, wrapper, kwargs, options)

--- a/tremolo/tremolo.py
+++ b/tremolo/tremolo.py
@@ -122,9 +122,12 @@ class Tremolo:
     def add_route(self, func, path='/', **options):
         if isinstance(func, type):  # a class-based view
             for name in dir(func):
+                if name.startswith('_'):
+                    continue
+
                 method = getattr(func, name)
 
-                if not name.startswith('_') and callable(method):
+                if callable(method):
                     self.routes.add(
                         method, path, dict(getoptions(method), self=func),
                         **options

--- a/tremolo/tremolo.py
+++ b/tremolo/tremolo.py
@@ -63,7 +63,7 @@ class Tremolo:
             return self.error(path)
 
         def decorator(func):
-            self.routes.add(func, path, getoptions(func))
+            self.add_route(func, path)
             return func
 
         return decorator
@@ -118,6 +118,18 @@ class Tremolo:
 
     def on_response(self, *args, **kwargs):
         return self.middleware('response', *args, **kwargs)
+
+    def add_route(self, func, path='/'):
+        if isinstance(func, type):  # a class-based view
+            for name in dir(func):
+                method = getattr(func, name)
+
+                if not name.startswith('_') and callable(method):
+                    self.routes.add(
+                        method, path, dict(getoptions(method), self=func)
+                    )
+        else:
+            self.routes.add(func, path, getoptions(func))
 
     def add_hook(self, func, name='worker_start', priority=999):
         if name not in self.hooks:


### PR DESCRIPTION
From the beginning, Tremolo exclusively supports only `@app.route`.
`@app.get`, `@app.post`, etc. are not implemented to prevent unnecessary lines of code or redundant API/methods.

To compensate, `@app.route` now supports decorating classes as well, so you can separate methods more cleanly.

**OLD:**
```python
@app.route('/hello')
async def hello_world(request, **server):
    if request.method == b'GET':
        return 'Hello, World!'

    if request.method == b'POST':
        return await request.body()

    raise MethodNotAllowed
```

**NEW:**
```python
@app.route('/hello')
class HelloWorld:
    async def get(self, **server):
        return 'Hello, World!'

    async def post(self, request, **server):
        return await request.body()

```

## Passing arbitrary options
Any arbitrary options in `@app.route(, **options)` or `app.add_route(, **options)` will be received in the class, in `__init__(, **kwargs)`.

This allows complex use cases.

```python
class HelloModel:
    def get_message(self):
        return 'Hello, clean architecture!'

    def set_message(self, message):
        self.msg = message


@app.route('/hello', model=HelloModel)
class HelloWorld:
    def __init__(self, model, **kwargs):
        self.model = model()

    async def get(self, **server):
        return self.model.get_message()

    async def post(self, request, **server):
        self.model.set_message(await request.body())
        return 'OK'


app.add_route(HelloWorld, '/hello101', model=AnotherModel)

```