### PR TITLE
allow multipart/form-data in request.form()

### DIFF
--- a/tests/http_server.py
+++ b/tests/http_server.py
@@ -314,6 +314,16 @@ async def upload_multipart(request, response, stream=False, **server):
         raise Exception('EOF!!!')
 
 
+@app.route('/upload/multipart/form')
+async def upload_multipart_form(request):
+    form_data = await request.form(max_size=262144)
+    files = request.params.files
+
+    yield files['file'][0]['data'][:5]  # b'BEGIN'
+    yield form_data['text'][0].encode()  # b'Hello, World!'
+    yield files['file'][0]['data'][-3:]  # b'END'
+
+
 @app.route('/download')
 async def download(request, response):
     if request.query_string == b'executor':

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -220,12 +220,21 @@ def create_multipart_body(boundary=b'----MultipartBoundary', **parts):
     body = bytearray(b'PREAMBLE')
 
     for name, data in parts.items():
+        name = name.encode('latin-1')
         body.extend(b'--%s\r\nContent-Length: %d\r\n' % (boundary, len(data)))
-        body.extend(b'Content-Disposition: form-data; name="%s"\r\n' %
-                    name.encode('latin-1'))
-        body.extend(
-            b'Content-Type: application/octet-stream\r\n\r\n%s\r\n' % data
-        )
+
+        if name.startswith(b'file'):
+            body.extend(
+                b'Content-Disposition: form-data; '
+                b'name="%s"; filename="%s.ext"\r\n' % (name, name)
+            )
+            body.extend(b'Content-Type: application/octet-stream\r\n')
+        else:
+            body.extend(
+                b'Content-Disposition: form-data; name="%s"\r\n' % name
+            )
+
+        body.extend(b'\r\n%s\r\n' % data)
 
     return bytes(body) + b'--%s--\r\nEPILOGUE' % boundary
 

--- a/tremolo/lib/http_request.py
+++ b/tremolo/lib/http_request.py
@@ -305,6 +305,7 @@ class HTTPRequest(Request):
         except KeyError as exc:
             content_type = self.headers.getlist(b'content-type', b';')
             self.params['post'] = {}
+            self.params['files'] = {}
 
             if b'application/x-www-form-urlencoded' in content_type:
                 async for data in self.stream():
@@ -323,7 +324,6 @@ class HTTPRequest(Request):
 
             if b'multipart/form-data' in content_type:
                 self._files = self.files(max_fields, max_file_size=max_size)
-                self.params['files'] = {}
 
                 async for part in self._files:
                     if not part.pop('eof'):

--- a/tremolo/lib/http_request.py
+++ b/tremolo/lib/http_request.py
@@ -303,25 +303,53 @@ class HTTPRequest(Request):
         try:
             return self.params['post']
         except KeyError as exc:
-            if (b'application/x-www-form-urlencoded' not in
-                    self.headers.getlist(b'content-type', b';')):
-                raise BadRequest('invalid Content-Type') from exc
-
-            async for data in self.stream():
-                self._body.extend(data)
-
-                if self.body_size > max_size:
-                    raise ValueError('form size limit reached') from exc
-
+            content_type = self.headers.getlist(b'content-type', b';')
             self.params['post'] = {}
 
-            if 2 < self.body_size <= max_size:
-                self.params['post'] = parse_qs(
-                    self._body.decode('latin-1'),
-                    max_num_fields=max_fields
-                )
+            if b'application/x-www-form-urlencoded' in content_type:
+                async for data in self.stream():
+                    self._body.extend(data)
 
-            return self.params['post']
+                    if self.body_size > max_size:
+                        raise ValueError('form size limit reached') from exc
+
+                if 2 < self.body_size <= max_size:
+                    self.params['post'] = parse_qs(
+                        self._body.decode('latin-1'),
+                        max_num_fields=max_fields
+                    )
+
+                return self.params['post']
+
+            if b'multipart/form-data' in content_type:
+                self._files = self.files(max_fields, max_file_size=max_size)
+                self.params['files'] = {}
+
+                async for part in self._files:
+                    if 'filename' in part:
+                        if part['filename'] == '':
+                            continue
+
+                        if not part['eof']:
+                            raise ValueError(
+                                'fragmented file. consider increasing the '
+                                'max_size limit or stream using files()'
+                            )
+
+                        self.params['files'][part['filename']] = part['data']
+                    elif 'name' in part:
+                        if part['name'] in self.params['post']:
+                            self.params['post'][part['name']].append(
+                                part['data'].decode()
+                            )
+                        else:
+                            self.params['post'][part['name']] = [
+                                part['data'].decode()
+                            ]
+
+                return self.params['post']
+
+            raise BadRequest('invalid Content-Type') from exc
 
     async def files(self, max_files=1024, *, max_file_size=100 * 1048576):
         if self.eof():


### PR DESCRIPTION
Allow `multipart/fom-data` to be read with `request.form()`.

Files will be populated to `request.params.files` (`dict`).

This is only suitable for handling small file uploads!!! - which when streaming using `request.files()` is overkill.
