### PR TITLE
move request.uid timestamp to the left

### DIFF
--- a/tremolo/lib/http_request.py
+++ b/tremolo/lib/http_request.py
@@ -121,9 +121,9 @@ class HTTPRequest(Request):
             port = self.client[1]  # 0 - 65535
 
         prefix = (
+            int(time.time() * 1e7).to_bytes(8, byteorder='big') +
             int.to_bytes((port << 16) | (os.getpid() & 0xffff),
-                         4, byteorder='big') +
-            int(time.time() * 1e7).to_bytes(8, byteorder='big')
+                         4, byteorder='big')
         )  # 12 Bytes
 
         return prefix + os.urandom(max(4, length - len(prefix)))


### PR DESCRIPTION
making it support chronological ordering. just like the UUIDv7 spirit.