### PR TITLE
ignore Content-Length in multipart

### DIFF
--- a/tests/http_server.py
+++ b/tests/http_server.py
@@ -285,17 +285,16 @@ async def upload_multipart(request, response, stream=False, **server):
     # should be ignored
     yield b''
 
-    yield b'name,length,type,data\r\n'
+    yield b'name,type,data\r\n'
 
     # should be ignored
     yield b''
 
     # stream multipart file upload then send it back as csv
     async for part in request.files(max_files=1):
-        yield b'%s,%d,%s,%s\r\n' % (part['name'].encode(),
-                                    part['length'],
-                                    part['type'].encode(),
-                                    (part['data'][:5] + part['data'][-3:]))
+        yield b'%s,%s,%s\r\n' % (part['name'].encode(),
+                                 part['type'].encode(),
+                                 (part['data'][:5] + part['data'][-3:]))
 
     async for part in request.files(max_file_size=262144):
         if part['eof']:
@@ -303,10 +302,9 @@ async def upload_multipart(request, response, stream=False, **server):
         else:
             part['data'] = part['data'][:5] + b'---'
 
-        yield b'%s,%d,%s,%s\r\n' % (part['name'].encode(),
-                                    part['length'],
-                                    part['type'].encode(),
-                                    (part['data'][:5] + part['data'][-3:]))
+        yield b'%s,%s,%s\r\n' % (part['name'].encode(),
+                                 part['type'].encode(),
+                                 (part['data'][:5] + part['data'][-3:]))
 
     async for part in request.files():
         # should not raised

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -336,10 +336,10 @@ class TestHTTPServer(unittest.TestCase):
         self.assertTrue(b'\r\nContent-Type: text/csv' in header)
         self.assertEqual(
             read_chunked(body) if chunked_detected(header) else body,
-            b'name,length,type,data\r\n'
-            b'file1,4096,application/octet-stream,BEGINEND\r\n'
-            b'file2,524288,application/octet-stream,BEGIN---\r\n'
-            b'file2,524288,application/octet-stream,-----END\r\n'
+            b'name,type,data\r\n'
+            b'file1,application/octet-stream,BEGINEND\r\n'
+            b'file2,application/octet-stream,BEGIN---\r\n'
+            b'file2,application/octet-stream,-----END\r\n'
         )
 
     def test_post_upload_multipart_form(self):


### PR DESCRIPTION
[4.8](https://datatracker.ietf.org/doc/html/rfc7578#section-4.8).  Other "Content-" Header Fields

   The multipart/form-data media type does not support any MIME header
   fields in parts other than Content-Type, Content-Disposition, and (in
   limited circumstances) Content-Transfer-Encoding.  Other header
   fields MUST NOT be included and MUST be ignored.