### PR TITLE
optimize chunked encoding parsing

### DIFF
--- a/tests/http_server.py
+++ b/tests/http_server.py
@@ -266,8 +266,12 @@ def upload(request, content_type=b'application/octet-stream', **server):
         size = int(request.query['size'][0])
         yield request.read(0) + request.read(size)
     except KeyError:
+        body = bytearray()
+
         for data in request.stream():
-            yield data
+            body.extend(data)
+
+        yield body
 
         for data in request.stream():
             # should not raised

--- a/tremolo/asgi_server.py
+++ b/tremolo/asgi_server.py
@@ -51,9 +51,8 @@ class ASGIServer(HTTPProtocol):
             'state': self.options['state'].copy()
         }
 
-        if self.options['experimental']:
-            # provide direct access to server objects
-            scope['state']['server'] = dict(self.server, response=response)
+        # provide direct access to server objects
+        scope['state']['server'] = dict(self.server, response=response)
 
         if (self.options['ws'] and b'sec-websocket-key' in request.headers and
                 b'upgrade' in request.headers and

--- a/tremolo/lib/http_protocol.py
+++ b/tremolo/lib/http_protocol.py
@@ -412,12 +412,11 @@ class HTTPProtocol(asyncio.Protocol):
             self.close(exc)
 
     async def _handle_keepalive(self):
-        if self.request.has_body:
-            if not self.request.eof():
-                self.logger.info('request body was not fully consumed')
-                self.request.clear()
-                self.close()
-                return
+        if self.request.has_body and not self.request.eof():
+            self.logger.info('request body was not fully consumed')
+            self.request.clear()
+            self.close()
+            return
 
         if 'receive' in self.events:
             # waits for all incoming data to enter the queue

--- a/tremolo/lib/http_protocol.py
+++ b/tremolo/lib/http_protocol.py
@@ -423,11 +423,6 @@ class HTTPProtocol(asyncio.Protocol):
                 self.close()
                 return
 
-            if b'transfer-encoding' in self.request.headers:
-                self.request.clear()
-                self.close()
-                return
-
         self.events['request'] = self.loop.create_future()
 
         self.add_task(self.app.create_task(
@@ -464,7 +459,7 @@ class HTTPProtocol(asyncio.Protocol):
                 self.print_exception(exc, 'connection_lost')
 
         while self.queue:
-            self.queue.pop().clear()
+            self.queue.pop().queue.clear()
 
         self.request = None
 

--- a/tremolo/lib/request.py
+++ b/tremolo/lib/request.py
@@ -56,7 +56,7 @@ class Request:
             except asyncio.CancelledError as exc:
                 raise TimeoutError('recv timeout') from exc
 
-            if data is None:
+            if data is None:  # only occurs on a request with Content-Length
                 break
 
             yield data


### PR DESCRIPTION
Connection reuse or keep-alive was previously disabled in cases of _chunked_ requests or requests without Content-Length to prevent desync.

It can now be enabled with `--experimental`, or `experimental=True` due to improved parsing.